### PR TITLE
replace logger and make fitting example simplier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+0.2.4 (2025-05-08)
+==================
+
+Documentation
+-------------
+
+- Simplified the spectral fitting example by making it single threaded.
+
+
 0.2.3 (2025-05-07)
 ==================
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -290,6 +290,9 @@ If you would like a bit more information, we have a similar function within `iri
       0  PRIMARY       1 PrimaryHDU     162   (555, 548, 20)   int16 (rescales to float32)
       1                1 ImageHDU        38   (31, 20)   float64
       2                1 TableHDU        33   20R x 5C   [A10, A10, A4, A66, A63]
+    INFO: Observation description: Very large sparse 16-step raster 15x175 16s   Deep x 0.5 Spatial x 2 [irispy.io.utils]
+    INFO: Extension No. 1 stores data and header of SJI_1330:  [irispy.io.utils]
+    INFO: 1310.00 - 1350.00 AA [irispy.io.utils]
 
 .. code-block:: python
 

--- a/examples/spectral_fitting.py
+++ b/examples/spectral_fitting.py
@@ -5,20 +5,13 @@ Spectral fitting
 
 In this example, we are going to fit spectral lines from IRIS, using the raster data with a single Gaussian.
 Then use the fitted values to calculate the Gaussian moments.
-
-This example is laid out like this so it can be run as a script without erroring.
-If you want to run it in a notebook, you can just copy the code below
-and paste it into a cell, you do not need the functions or the ``if __name__ == "__main__":`` part.
 """
 
-import shutil
 import warnings
-from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pooch
-from dask.distributed import Client
 
 import astropy.units as u
 from astropy import constants
@@ -31,6 +24,8 @@ from sunpy.coordinates import frames
 
 from irispy.io import read_files
 
+time_support()
+
 ###############################################################################
 # We will start by getting some data from the IRIS archive.
 #
@@ -40,13 +35,10 @@ from irispy.io import read_files
 # Using the url: http://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2018/01/02/20180102_153155_3610108077/iris_l2_20180102_153155_3610108077_raster.tar.gz
 # we are after the raster sequence (~300 MB).
 
-
-def get_data():
-    return pooch.retrieve(
-        "http://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2018/01/02/20180102_153155_3610108077/iris_l2_20180102_153155_3610108077_raster.tar.gz",
-        known_hash="0ec2b7b20757c52b02e0d92c27a5852b6e28759512c3d455f8b6505d4e1f5cd6",
-    )
-
+raster_filename = pooch.retrieve(
+    "http://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2018/01/02/20180102_153155_3610108077/iris_l2_20180102_153155_3610108077_raster.tar.gz",
+    known_hash="0ec2b7b20757c52b02e0d92c27a5852b6e28759512c3d455f8b6505d4e1f5cd6",
+)
 
 ###############################################################################
 # Now to open the files using ``irispy-lmsal``.
@@ -57,62 +49,46 @@ def get_data():
 #
 # We will use ``memmap=False`` because we want to fit the actual the data values.
 
-
-def read_file(raster_filename):
-    return read_files(raster_filename, memmap=False)
-
+raster = read_files(raster_filename, memmap=False)
 
 ###############################################################################
 # We will just focus on the Si IV 1403 line which we can select using a key.
 # Then we will just plot a spectral line selected at random in space.
 
+# There is only one complete scan, so we index that away.
+si_iv_1403 = raster["Si IV 1403"][0]
 
-def get_si_iv_1403(raster):
-    # There is only one complete scan, so we index that away.
-    si_iv_1403 = raster["Si IV 1403"][0]
-
-    # However, before we get to that, we will shrink the data cube to make it easier to work with.
-    top_left = [None, SkyCoord(-290 * u.arcsec, 260 * u.arcsec, frame=frames.Helioprojective)]
-    bottom_right = [None, SkyCoord(-360 * u.arcsec, 310 * u.arcsec, frame=frames.Helioprojective)]
-    return si_iv_1403.crop(top_left, bottom_right)
+# However, before we get to that, we will shrink the data cube to make it easier to work with.
+top_left = [None, SkyCoord(-290 * u.arcsec, 260 * u.arcsec, frame=frames.Helioprojective)]
+bottom_right = [None, SkyCoord(-360 * u.arcsec, 310 * u.arcsec, frame=frames.Helioprojective)]
+si_iv_1403 = si_iv_1403.crop(top_left, bottom_right)
 
 
 ###############################################################################
 # Let us just check the full field of view at the line core.
 
+si_iv_core = 140.277 * u.nm
+lower_corner = [SpectralCoord(si_iv_core), None]
+upper_corner = [SpectralCoord(si_iv_core), None]
+si_iv_spec_crop = si_iv_1403.crop(lower_corner, upper_corner)
 
-def quicklook_si_iv_1403(si_iv_1403, si_iv_core):
-    lower_corner = [SpectralCoord(si_iv_core), None]
-    upper_corner = [SpectralCoord(si_iv_core), None]
-    si_iv_spec_crop = si_iv_1403.crop(lower_corner, upper_corner)
-
-    fig = plt.figure()
-    ax = fig.add_subplot(111, projection=si_iv_spec_crop.wcs)
-    ax = si_iv_spec_crop.plot(axes=ax, vmin=0, vmax=100)
-
-    return si_iv_spec_crop, fig
-
+fig = plt.figure()
+ax = fig.add_subplot(111, projection=si_iv_spec_crop.wcs)
+ax = si_iv_spec_crop.plot(axes=ax, vmin=0, vmax=100)
 
 ###############################################################################
 # We will want to make two rebinned cubes from the full raster,
 # one summed along the wavelength dimension and one of the spectra averaged over all spatial pixels.
 
-
-def get_averages(si_iv_1403):
-    wl_sum = si_iv_1403.rebin((1, 1, si_iv_1403.data.shape[-1]), operation=np.sum)[0]
-    spatial_mean = si_iv_1403.rebin((*si_iv_1403.data.shape[:-1], 1))[0, 0, :]
-    return wl_sum, spatial_mean
-
+wl_sum = si_iv_1403.rebin((1, 1, si_iv_1403.data.shape[-1]), operation=np.sum)[0]
+spatial_mean = si_iv_1403.rebin((*si_iv_1403.data.shape[:-1], 1))[0, 0, :]
 
 ################################################################################
 # Now we can create a model for this spectra.
 
-
-def setup_initial_model(si_iv_1403, si_iv_core):
-    return m.Const1D(amplitude=2 * si_iv_1403.unit) + m.Gaussian1D(
-        amplitude=8 * si_iv_1403.unit, mean=si_iv_core, stddev=0.005 * u.nm
-    )
-
+initial_model = m.Const1D(amplitude=2 * si_iv_1403.unit) + m.Gaussian1D(
+    amplitude=8 * si_iv_1403.unit, mean=si_iv_core, stddev=0.005 * u.nm
+)
 
 ################################################################################
 # To improve our initial conditions we now fit the initial model to the spatially averaged spectra.
@@ -121,30 +97,21 @@ def setup_initial_model(si_iv_1403, si_iv_core):
 # correlated with. So in this case we get the wavelength dimension which only
 # returns a single `SpectralCoord` object corresponding to the first array dimension of the cube.
 
-
-def get_average_fit(initial_model, spatial_mean):
-    fitter = LevMarLSQFitter(calc_uncertainties=True)
-    return fitter(
-        initial_model,
-        spatial_mean.axis_world_coords("em.wl")[0].to(u.nm),
-        spatial_mean.data * spatial_mean.unit,
-    )
-
+fitter = LevMarLSQFitter()
+average_fit = fitter(
+    initial_model,
+    spatial_mean.axis_world_coords("em.wl")[0].to(u.nm),
+    spatial_mean.data * spatial_mean.unit,
+)
 
 ################################################################################
 # Now we check, the initial model and the model fitted to the average spectra.
 
-
-def plot_initial_model(initial_model, spatial_mean, average_fit):
-    fig = plt.figure()
-    ax = spatial_mean.plot(label="Spatial average")
-    ax.plot(initial_model(spatial_mean.axis_world_coords("em.wl")[0].to(u.nm)), label="Initial model")
-    ax.plot(
-        average_fit(spatial_mean.axis_world_coords("em.wl")[0].to(u.nm)), linestyle="--", label="Spatial average fit"
-    )
-    plt.legend()
-    return fig
-
+fig = plt.figure()
+ax = spatial_mean.plot(label="Spatial average")
+ax.plot(initial_model(spatial_mean.axis_world_coords("em.wl")[0].to(u.nm)), label="Initial model")
+ax.plot(average_fit(spatial_mean.axis_world_coords("em.wl")[0].to(u.nm)), linestyle="--", label="Spatial average fit")
+plt.legend()
 
 ################################################################################
 # The function `.parallel_fit_dask` will map a model to each element of a cube along
@@ -164,120 +131,76 @@ def plot_initial_model(initial_model, spatial_mean, average_fit):
 # What is returned from `.parallel_fit_dask` is a model with array parameters with
 # the shape of the non-fitting axes of the data.
 
+# We want to do some basic data sanitization.
+# Remove negative values and set them to zero and remove non-finite values.
+filtered_data = np.where(si_iv_1403.data < 0, 0, si_iv_1403.data)
+filtered_data = np.where(np.isfinite(filtered_data), filtered_data, 0)
 
-def do_fitting(si_iv_1403, average_fit):
-    """
-    This function will do the fitting.
-
-    It is not needed if you are running this in a notebook.
-    """
-    # First we will start a local dask client to improve the fitting performance
-    client = Client()
-
-    # Next we will want to setup error reporting
-    # Since it is using multiprocess/dask, logs are returned instead of errors
-    diag_path = Path("./diag")
-    shutil.rmtree(diag_path, ignore_errors=True)
-
-    # LevMarLSQFitter does not like negative values, so we need to filter the data
-    # You can also set a mask but for now, we will just handle the data.
-    filtered_data = np.where(si_iv_1403.data < 0, 0, si_iv_1403.data)
-    # We also need to set any NaN nor non-finite values to 0, otherwise the fitting will fail
-    filtered_data = np.where(~np.isfinite(filtered_data), 0, filtered_data)
-
-    # We can therefore fit the cube as follows
-    with warnings.catch_warnings():
-        # There are several WCS warnings we just want to ignore
-        warnings.simplefilter("ignore")
-        iris_model_fit = parallel_fit_dask(
-            data=filtered_data,
-            data_unit=si_iv_1403.unit,
-            fitting_axes=2,
-            world=si_iv_1403.wcs,
-            model=average_fit,
-            fitter=LevMarLSQFitter(),
-            diagnostics="error",
-            diagnostics_path=diag_path,
-            scheduler=client,
-        )
-    diag_folders = list(diag_path.glob("*"))
-    errors = []
-    for diag in diag_folders:
-        if (path := (diag / "error.log")).exists():
-            content = open(path).read()
-            errors.append(content)
-    print(f"{len(errors)} errors occurred")
-    if errors:
-        print("First error is:")
-        print(errors[0])
-
-    client.close()
-    return iris_model_fit
-
-
-################################################################################
-# Given that we are going to want to visualize the output, a simple plotting
-# function below has been created for this purpose.
-
-
-def plot_gaussian_fit(model_fit, si_iv_spec_crop, si_iv_core):
-    fig, axs = plt.subplots(nrows=1, ncols=3, subplot_kw={"projection": si_iv_spec_crop}, figsize=(16, 6))
-
-    net_flux = (
-        np.sqrt(2 * np.pi)
-        * (model_fit.amplitude_0 + model_fit.amplitude_1)
-        * model_fit.stddev_1.quantity
-        / np.mean(si_iv_1403.axis_world_coords("wl")[0][1:] - si_iv_1403.axis_world_coords("wl")[0][:-1])
+# We can therefore fit the cube
+with warnings.catch_warnings():
+    # There are several WCS warnings we just want to ignore
+    warnings.simplefilter("ignore")
+    iris_model_fit = parallel_fit_dask(
+        data=filtered_data,
+        data_unit=si_iv_1403.unit,
+        fitting_axes=2,
+        world=si_iv_1403.wcs,
+        model=average_fit,
+        fitter=LevMarLSQFitter(),
+        scheduler="single-threaded",
     )
-    amp_max = np.nanpercentile(np.abs(net_flux.value), 99)
-    amp = axs[0].imshow(net_flux.value, vmin=0, vmax=amp_max, origin="lower")
-    cbar = fig.colorbar(amp, ax=axs[0])
-    cbar.set_label(label=f"Intensity [{net_flux.unit.to_string()}]", fontsize=8)
-    cbar.ax.tick_params(labelsize=8)
-    axs[0].set_title("Gaussian Net Flux")
 
-    core_shift = ((model_fit.mean_1.quantity.to(u.nm)) - si_iv_core) / si_iv_core * (constants.c.to(u.km / u.s))
-    shift_max = np.nanpercentile(np.abs(core_shift.value), 95)
-    shift = axs[1].imshow(core_shift.value, cmap="coolwarm", vmin=-shift_max, vmax=shift_max)
-    cbar = fig.colorbar(shift, ax=axs[1], extend="both")
-    cbar.set_label(label=f"Doppler shift [{core_shift.unit.to_string()}]", fontsize=8)
-    cbar.ax.tick_params(labelsize=8)
-    axs[1].set_title("Velocity from Gaussian shift")
-
-    sigma = (model_fit.stddev_1.quantity.to(u.nm)) / si_iv_core * (constants.c.to(u.km / u.s))
-    line_max = np.nanpercentile(np.abs(sigma.value), 95)
-    line = axs[2].imshow(sigma.value, vmax=line_max)
-    cbar = fig.colorbar(line, ax=axs[2])
-    cbar.set_label(label=f"Line Width [{sigma.unit.to_string()}]", fontsize=8)
-    cbar.ax.tick_params(labelsize=8)
-    axs[2].set_title("Gaussian Sigma")
-
-    for ax in axs:
-        ax.coords[0].set_ticklabel(exclude_overlapping=True, fontsize=8)
-        ax.coords[0].set_axislabel("Helioprojective Longitude", fontsize=8)
-        ax.coords[1].set_ticklabel(exclude_overlapping=True, fontsize=8)
-        ax.coords[1].set_axislabel("Helioprojective Latitude", fontsize=8)
-    fig.tight_layout()
-    return fig
-
+# Note that this example is done in a single thread. If you want to use multiple cores.
+# You can create a dask client and pass it to the parallel_fit_dask function.
+# For example:
+#
+# from dask.distributed import Client
+#
+# client = Client()
+#
+# Then pass this to the parallel_fit_dask function by replacing scheduler line above with:
+#
+# scheduler=client,
+#
 
 ################################################################################
 # Let us see the output!
 
-if __name__ == "__main__":
-    time_support()
+fig, axs = plt.subplots(nrows=1, ncols=3, subplot_kw={"projection": si_iv_spec_crop}, figsize=(16, 6))
+net_flux = (
+    np.sqrt(2 * np.pi)
+    * (iris_model_fit.amplitude_0 + iris_model_fit.amplitude_1)
+    * iris_model_fit.stddev_1.quantity
+    / np.mean(si_iv_1403.axis_world_coords("wl")[0][1:] - si_iv_1403.axis_world_coords("wl")[0][:-1])
+)
+amp_max = np.nanpercentile(np.abs(net_flux.value), 99)
+amp = axs[0].imshow(net_flux.value, vmin=0, vmax=amp_max, origin="lower")
+cbar = fig.colorbar(amp, ax=axs[0])
+cbar.set_label(label=f"Intensity [{net_flux.unit.to_string()}]", fontsize=8)
+cbar.ax.tick_params(labelsize=8)
+axs[0].set_title("Gaussian Net Flux")
 
-    raster_filename = get_data()
-    raster = read_file(raster_filename)
-    si_iv_1403 = get_si_iv_1403(raster)
-    si_iv_core = 140.277 * u.nm
-    si_iv_spec_crop, quicklook_fig = quicklook_si_iv_1403(si_iv_1403, si_iv_core)
+core_shift = ((iris_model_fit.mean_1.quantity.to(u.nm)) - si_iv_core) / si_iv_core * (constants.c.to(u.km / u.s))
+shift_max = np.nanpercentile(np.abs(core_shift.value), 95)
+shift = axs[1].imshow(core_shift.value, cmap="coolwarm", vmin=-shift_max, vmax=shift_max)
+cbar = fig.colorbar(shift, ax=axs[1], extend="both")
+cbar.set_label(label=f"Doppler shift [{core_shift.unit.to_string()}]", fontsize=8)
+cbar.ax.tick_params(labelsize=8)
+axs[1].set_title("Velocity from Gaussian shift")
 
-    wl_sum, spatial_mean = get_averages(si_iv_1403)
-    initial_model = setup_initial_model(si_iv_1403, si_iv_core)
-    average_fit = get_average_fit(initial_model, spatial_mean)
-    initial_fig = plot_initial_model(initial_model, spatial_mean, average_fit)
+sigma = (iris_model_fit.stddev_1.quantity.to(u.nm)) / si_iv_core * (constants.c.to(u.km / u.s))
+line_max = np.nanpercentile(np.abs(sigma.value), 95)
+line = axs[2].imshow(sigma.value, vmax=line_max)
+cbar = fig.colorbar(line, ax=axs[2])
+cbar.set_label(label=f"Line Width [{sigma.unit.to_string()}]", fontsize=8)
+cbar.ax.tick_params(labelsize=8)
+axs[2].set_title("Gaussian Sigma")
 
-    iris_model_fit = do_fitting(si_iv_1403, average_fit)
-    guass_fig = plot_gaussian_fit(iris_model_fit, si_iv_spec_crop, si_iv_core)
-    plt.show()
+for ax in axs:
+    ax.coords[0].set_ticklabel(exclude_overlapping=True, fontsize=8)
+    ax.coords[0].set_axislabel("Helioprojective Longitude", fontsize=8)
+    ax.coords[1].set_ticklabel(exclude_overlapping=True, fontsize=8)
+    ax.coords[1].set_axislabel("Helioprojective Latitude", fontsize=8)
+fig.tight_layout()
+
+plt.show()

--- a/examples/spectral_fitting.py
+++ b/examples/spectral_fitting.py
@@ -74,7 +74,9 @@ si_iv_spec_crop = si_iv_1403.crop(lower_corner, upper_corner)
 
 fig = plt.figure()
 ax = fig.add_subplot(111, projection=si_iv_spec_crop.wcs)
-ax = si_iv_spec_crop.plot(axes=ax, vmin=0, vmax=100)
+si_iv_spec_crop.plot(axes=ax, vmin=0, vmax=200)
+plt.title("Si IV 1402.77 A")
+plt.colorbar(label="Intensity [DN]", shrink=0.8)
 
 ###############################################################################
 # We will want to make two rebinned cubes from the full raster,

--- a/examples/spectral_fitting.py
+++ b/examples/spectral_fitting.py
@@ -6,6 +6,7 @@ Spectral fitting
 In this example, we are going to fit spectral lines from IRIS, using the raster data with a single Gaussian.
 Then use the fitted values to calculate the Gaussian moments.
 """
+# sphinx_gallery_thumbnail_number = 3
 
 import warnings
 
@@ -62,7 +63,6 @@ si_iv_1403 = raster["Si IV 1403"][0]
 top_left = [None, SkyCoord(-290 * u.arcsec, 260 * u.arcsec, frame=frames.Helioprojective)]
 bottom_right = [None, SkyCoord(-360 * u.arcsec, 310 * u.arcsec, frame=frames.Helioprojective)]
 si_iv_1403 = si_iv_1403.crop(top_left, bottom_right)
-
 
 ###############################################################################
 # Let us just check the full field of view at the line core.

--- a/irispy/data/_sample.py
+++ b/irispy/data/_sample.py
@@ -79,7 +79,7 @@ def _handle_final_errors(results):
 
 def _get_sampledata_dir():
     # Workaround for tox only. This is not supported as a user option
-    sampledata_dir = os.environ.get("SUNPY_SAMPLEDIR", False)
+    sampledata_dir = os.environ.get("SUNPY_SAMPLEDIR", "")
     if sampledata_dir:
         sampledata_dir = Path(sampledata_dir).expanduser().resolve()
         _is_writable_dir(sampledata_dir)

--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -1,4 +1,3 @@
-import logging
 import tarfile
 from copy import copy
 from pathlib import Path
@@ -11,6 +10,7 @@ from astropy.io import fits
 from astropy.time import Time, TimeDelta
 from astropy.wcs import WCS
 
+from sunpy import log as logger
 from sunpy.coordinates import Helioprojective
 
 from irispy.spectrograph import Collection, SGMeta, SpectrogramCube, SpectrogramCubeSequence
@@ -153,7 +153,7 @@ def read_spectrograph_lvl2(
                         "The loading will continue but this will be missing in the final cube. "
                         f"Spectral window: {window_name}, step {i} in file: {filename}"
                     )
-                    logging.warning(msg)
+                    logger.warning(msg)
                     continue
                 out_uncertainty = None
                 data_mask = None

--- a/irispy/io/utils.py
+++ b/irispy/io/utils.py
@@ -1,8 +1,9 @@
-import logging
 import tarfile
 from pathlib import Path
 
 from astropy.io import fits
+
+from sunpy import log as logger
 
 __all__ = ["fitsinfo", "read_files"]
 
@@ -21,15 +22,15 @@ def fitsinfo(filename):
         hdulist.info()
         hdr = hdulist[0].header
         msg = f"Observation description: {hdr['OBS_DESC']}"
-        logging.info(msg)
+        logger.info(msg)
         modifier = ""
         for i in range(hdr["NWIN"]):
             msg = f"Extension No. {i + 1} stores data and header of {hdr[f'TDESC{i + 1}']}: "
-            logging.info(msg)
+            logger.info(msg)
             if "SJI" not in hdr[f"TDET{i + 1}"]:
                 modifier = f" ({hdr[f'TDET{i + 1}'][:3]})"
             msg = f"{hdr[f'TWMIN{i + 1}']:.2f} - {hdr[f'TWMAX{i + 1}']:.2f} AA{modifier}"
-            logging.info(msg)
+            logger.info(msg)
 
 
 def read_files(filename, *, spectral_windows=None, uncertainty=False, memmap=False):

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -1,8 +1,8 @@
-import logging
 import textwrap
 
 import matplotlib.pyplot as plt
 
+from sunpy import log as logger
 from sunraster import SpectrogramCube
 
 from irispy.utils import calculate_dust_mask
@@ -118,7 +118,7 @@ class SJICube(SpectrogramCube):
             try:
                 cmap = plt.get_cmap(name=f"irissji{int(self.meta['TWAVE1'])}")
             except Exception as e:  # NOQA: BLE001
-                logging.debug(e)
+                logger.debug(e)
                 cmap = "viridis"
         kwargs["cmap"] = cmap
         ax = Plotter(ndcube=self).plot(*args, **kwargs)

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -1,4 +1,3 @@
-import logging
 import textwrap
 
 import matplotlib.pyplot as plt
@@ -10,6 +9,7 @@ from astropy.time import Time
 
 from ndcube import NDCollection
 from ndcube.meta import NDMeta
+from sunpy import log as logger
 from sunpy.coordinates import Helioprojective
 from sunraster import SpectrogramCube as SpecCube
 from sunraster import SpectrogramSequence as SpecSeq
@@ -137,7 +137,7 @@ class SpectrogramCube(SpecCube):
             try:
                 cmap = plt.get_cmap(name=f"irissji{int(self.meta.detector[:3])}")
             except Exception as e:  # NOQA: BLE001
-                logging.debug(e)
+                logger.debug(e)
                 cmap = "viridis"
         kwargs["cmap"] = cmap
         if len(self.shape) == 1:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 # Allow unused variables when underscore-prefixed.
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-target-version = "py311"
+target-version = "py310"
 line-length = 120
 extend-exclude=[
     "__pycache__",


### PR DESCRIPTION
## Summary by Sourcery

Simplify the spectral fitting example and replace logging with sunpy logger

Enhancements:
- Refactored spectral fitting example to remove unnecessary function definitions
- Simplified code structure in the example script

Chores:
- Updated ruff configuration to target Python 3.10
- Replaced standard logging with sunpy logger across multiple files