### PR TITLE
Add v34 raster example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 exclude: ".*(.fits|.fts|.fit|.header|.txt|tca.*|extern.*|irispy/extern|^CITATION.rst)$"
 repos:
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.6
+    rev: v1.7.7
     hooks:
       - id: docformatter
         args: ["--in-place", "--pre-summary-newline", "--make-summary-multi"]
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.8"
+    rev: "v0.11.11"
     hooks:
       - id: ruff
         args: ["--fix", "--unsafe-fixes"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@ Configuration file for the Sphinx documentation builder.
 """
 
 import datetime
-import os
 from pathlib import Path
 
 from sunpy_sphinx_theme import PNG_ICON
@@ -19,7 +18,6 @@ is_development = ".dev" in __version__
 
 # -- General configuration ---------------------------------------------------
 extensions = [
-    "hoverxref.extension",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_automodapi.automodapi",
@@ -41,38 +39,6 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 source_suffix = ".rst"
 master_doc = "index"
 default_role = "obj"
-
-# -- Options for hoverxref -----------------------------------------------------
-if os.environ.get("READTHEDOCS"):
-    hoverxref_api_host = "https://readthedocs.org"
-    if os.environ.get("PROXIED_API_ENDPOINT"):
-        # Use the proxied API endpoint
-        # - A RTD thing to avoid a CSRF block when docs are using a
-        #   custom domain
-        hoverxref_api_host = "/_"
-
-hoverxref_tooltip_maxwidth = 600  # RTD main window is 696px
-hoverxref_auto_ref = True
-hoverxref_mathjax = True
-# hoverxref has to be applied to these
-hoverxref_domains = ["py"]
-hoverxref_role_types = {
-    # roles with py domain
-    "attr": "tooltip",
-    "class": "tooltip",
-    "const": "tooltip",
-    "data": "tooltip",
-    "exc": "tooltip",
-    "func": "tooltip",
-    "meth": "tooltip",
-    "mod": "tooltip",
-    "obj": "tooltip",
-    # roles with std domain
-    "confval": "tooltip",
-    "hoverxref": "tooltip",
-    "ref": "tooltip",
-    "term": "tooltip",
-}
 
 # -- Options for sphinx-copybutton ---------------------------------------------
 # Python Repl + continuation, Bash, ipython and qtconsole + continuation, jupyter-console + continuation

--- a/examples/v34_rasters.py
+++ b/examples/v34_rasters.py
@@ -72,6 +72,8 @@ ax = fig.add_subplot(121, projection=mg_spec_crop.wcs)
 ax.set_title("v34 flipped")
 mg_spec_crop.plot(axes=ax, plot_axes=["x", "y"])
 
+# sphinx_gallery_defer_figures
+
 ###############################################################################
 # Now let us compare the results with the unflipped data.
 
@@ -91,4 +93,5 @@ plt.show()
 # The same is true for the times in the raster:
 
 print(f"Flipped time: {mg_ii_k.time[:5]}")
+print("*" * 50)
 print(f"Unflipped time: {mg_ii_k_unflipped.time[:5]}")

--- a/examples/v34_rasters.py
+++ b/examples/v34_rasters.py
@@ -1,0 +1,89 @@
+"""
+=============================
+Dealing with IRIS v34 rasters
+=============================
+
+In this example we will show irispy-lmsal deals with a v34 dataset by default and how to
+undo that if you so desire.
+
+These v34 are scans which raster from west to east instead of the default east to west.
+"""
+
+import matplotlib.pyplot as plt
+import pooch
+
+import astropy.units as u
+from astropy.coordinates import SpectralCoord
+
+from irispy.io import read_files
+
+###############################################################################
+# We start by downloading a raster v34 dataset from the IRIS archive.
+#
+# In this case, we will use ``pooch`` to keep this example self-contained
+# but using your browser will also work.
+#
+# This is a very large sparse 64-step raster with a FOV of 63"x175" for
+# a total of 8 complete raster scans.
+
+raster_filename = pooch.retrieve(
+    "https://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2025/03/28/20250328_225628_3400109360/iris_l2_20250328_225628_3400109360_raster.tar.gz",
+    known_hash="fe890425c61a8d36e08806df19957ca264e62e13d7cda7e8d0a8f896ddd73db1",
+)
+
+###############################################################################
+# We will now open the raster file we just downloaded.
+
+raster = read_files(raster_filename, memmap=False)
+# We will also undo the v34 handling and read the data as it is in the file.
+# This will be used later to compare the results.
+raster_unflipped = read_files(raster_filename, memmap=False, revert_v34=True)
+
+# Printing will give us an overview of the file.
+print(raster)
+
+###############################################################################
+# We will now pull the 'Mg II k 2796' spectral line data from the raster.
+
+mg_ii_k = raster["Mg II k 2796"]
+mg_ii_k_unflipped = raster_unflipped["Mg II k 2796"]
+print(mg_ii_k)
+
+###############################################################################
+# So by default, irispy-lmsal will read the v34 data, flipping the data so that it
+# is in the same orientation as normal IRIS data and adjust the WCS accordingly.
+
+fig = plt.figure()
+mg_ii_k.plot(fig=fig, clip_interval=(0.1, 99.9) * u.percent)
+
+###############################################################################
+# To confirm this we will plot spectroheliogram for Mg II k core wavelength.
+# We can use the ``crop`` method to get this information, this will
+# require a `~.SpectralCoord` object from `astropy.coordinates`.
+
+# None, means that the axis is not cropped
+# Note that this has to be in axis order
+lower_corner = [SpectralCoord(280, unit=u.nm), None]
+upper_corner = [SpectralCoord(280, unit=u.nm), None]
+mg_spec_crop = mg_ii_k[0].crop(lower_corner, upper_corner)
+
+fig = plt.figure(figsize=(6, 12))
+ax = fig.add_subplot(121, projection=mg_spec_crop.wcs)
+ax.set_title("v34 flipped")
+mg_spec_crop.plot(axes=ax, plot_axes=["x", "y"])
+
+###############################################################################
+# Now let us compare the results with the unflipped data.
+
+mg_spec_unflipped_crop = mg_ii_k_unflipped[0].crop(lower_corner, upper_corner)
+
+ax2 = fig.add_subplot(122, projection=mg_spec_unflipped_crop.wcs)
+ax2.set_title("v34 unflipped")
+mg_spec_unflipped_crop.plot(axes=ax2, plot_axes=["x", "y"])
+fig.tight_layout()
+
+plt.show()
+
+###############################################################################
+# As you can see, the v34 data is flipped in the y-axis and the WCS is
+# adjusted accordingly.

--- a/examples/v34_rasters.py
+++ b/examples/v34_rasters.py
@@ -87,3 +87,8 @@ plt.show()
 ###############################################################################
 # As you can see, the v34 data is flipped in the y-axis and the WCS is
 # adjusted accordingly.
+#
+# The same is true for the times in the raster:
+
+print(f"Flipped time: {mg_ii_k.time[:5]}")
+print(f"Unflipped time: {mg_ii_k_unflipped.time[:5]}")

--- a/examples/working_with_rasters.py
+++ b/examples/working_with_rasters.py
@@ -89,8 +89,6 @@ ax = fig.add_subplot(111, projection=mg_ii[120, 200].wcs)
 mg_ii[120, 200].plot(axes=ax)
 
 ###############################################################################
-# Note that the values are unscaled due to the ``memmap=True`` setting.
-#
 # We can also plot using the data directly. We can read the wavelengths of the
 # Mg window by calling `ndcube.NDCube.axis_world_coords` for "wl" (wavelength), and redo the plot.
 

--- a/examples/working_with_rasters.py
+++ b/examples/working_with_rasters.py
@@ -74,9 +74,11 @@ mg_ii.plot(fig=fig)
 
 fig = plt.figure()
 # This will also "transpose" the data but this is only for visualization purposes
-# We have to set the vmin and vmax or in this case, clip_interval, as by default
-# "plot" works out the vmin,vmax from the first slice which in this case is 0.
-mg_ii.plot(fig=fig, plot_axes=["x", "y", None], clip_interval=(1, 99.9) * u.percent)
+# We have to set the vmin and vmax, as by default "plot" works out the
+# vmin,vmax from the first slice which in this case is 0.
+mg_ii.plot(fig=fig, plot_axes=["x", "y", None], vmin=0, vmax=1000).get_animation()
+# The call to `get_animation()` is necessary to display the animation in this example.
+# It is not needed in a normal script.
 
 ###############################################################################
 # This object is sliceable, so we can do things like this:

--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -166,6 +166,7 @@ def read_spectrograph_lvl2(
                         dn_unit,
                     )
                 if v34 and not revert_v34:
+                    times = times[::-1]
                     data = np.flip(hdulist[window_fits_indices[i]].data, axis=0)
                     header["PC1_3"] = 0
                     header["PC2_3"] = -header["PC2_3"]

--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -167,9 +167,10 @@ def read_spectrograph_lvl2(
                     )
                 if v34 and not revert_v34:
                     data = np.flip(hdulist[window_fits_indices[i]].data, axis=0)
+                    header["PC1_3"] = 0
                     header["PC2_3"] = -header["PC2_3"]
                     header["PC3_2"] = -header["PC3_2"]
-                    header["CDELT3"] = np.abs(header["CDELT3"])
+                    header["CDELT3"] = -header["CDELT3"]
                     header["CRPIX3"] = header["NAXIS3"] - header["CRPIX3"] + 1
                     wcs = WCS(header)
                 else:

--- a/irispy/io/utils.py
+++ b/irispy/io/utils.py
@@ -33,7 +33,7 @@ def fitsinfo(filename):
             logger.info(msg)
 
 
-def read_files(filename, *, spectral_windows=None, uncertainty=False, memmap=False):
+def read_files(filename, *, spectral_windows=None, uncertainty=False, memmap=False, **kwargs):
     """
     A wrapper function to read a raster or SJI level 2 data file.
 
@@ -58,6 +58,8 @@ def read_files(filename, *, spectral_windows=None, uncertainty=False, memmap=Fal
         the file into memory when needed. This option is faster and uses a
         lot less memory. However, because FITS scaling is not done on-the-fly,
         the data units will be unscaled, not the usual data numbers (DN).
+    kwargs : `dict`, optional
+        Additional keyword arguments to pass to the reader functions.
 
     Returns
     -------
@@ -86,13 +88,14 @@ def read_files(filename, *, spectral_windows=None, uncertainty=False, memmap=Fal
         if len(filename) > 1:
             msg = "You cannot load more than one SJI file at a time."
             raise ValueError(msg)
-        return read_sji_lvl2(filename[0], memmap=memmap, uncertainty=uncertainty)
+        return read_sji_lvl2(filename[0], memmap=memmap, uncertainty=uncertainty, **kwargs)
     if intrume == "SPEC":
         return read_spectrograph_lvl2(
             filename,
             spectral_windows=spectral_windows,
             memmap=memmap,
             uncertainty=uncertainty,
+            **kwargs,
         )
     msg = f"Unsupported instrument: {intrume}"
     raise ValueError(msg)

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -18,7 +18,7 @@ from sunraster.spectrogram import APPLY_EXPOSURE_TIME_ERROR
 
 from irispy import utils
 from irispy.utils.constants import SPECTRAL_BAND
-from irispy.visualization import Plotter, set_axis_properties
+from irispy.visualization import Plotter, SequencePlotter, set_axis_properties
 
 __all__ = ["Collection", "SGMeta", "SpectrogramCube", "SpectrogramCubeSequence"]
 
@@ -290,6 +290,21 @@ class SpectrogramCubeSequence(SpecSeq):
     def __str__(self) -> str:
         # Overload it get the class name in the string
         return super().__str__()
+
+    def plot(self, *args, **kwargs):
+        cmap = kwargs.get("cmap")
+        if not cmap:
+            try:
+                cmap = plt.get_cmap(name=f"irissji{int(self.meta.detector[:3])}")
+            except Exception as e:  # NOQA: BLE001
+                logger.debug(e)
+                cmap = "viridis"
+        kwargs["cmap"] = cmap
+        if len(self.shape) == 1:
+            kwargs.pop("cmap")
+        ax = SequencePlotter(ndcube=self).plot(*args, **kwargs)
+        set_axis_properties(ax)
+        return ax
 
     def convert_to(self, new_unit_type, *, copy=False):
         """

--- a/irispy/visualization.py
+++ b/irispy/visualization.py
@@ -4,8 +4,9 @@ import astropy.units as u
 
 import sunpy.visualization.colormaps as cm  # NOQA: F401
 from ndcube.visualization.mpl_plotter import MatplotlibPlotter
+from ndcube.visualization.mpl_sequence_plotter import MatplotlibSequencePlotter
 
-__all__ = ["CustomArrayAnimatorWCS", "Plotter", "set_axis_properties"]
+__all__ = ["CustomArrayAnimatorWCS", "Plotter", "SequencePlotter"]
 
 
 LAT_LABELS = [
@@ -72,6 +73,24 @@ class CustomArrayAnimatorWCS(ArrayAnimatorWCS):
 
 
 class Plotter(MatplotlibPlotter):
+    def plot(self, *args, **kwargs):
+        return super().plot(*args, **kwargs)
+
+    def _animate_cube(
+        self,
+        wcs,
+        plot_axes=None,
+        axes_coordinates=None,  # NOQA: ARG002 - Unused but passed in via ModestImage.set
+        axes_units=None,
+        data_unit=None,
+        **kwargs,
+    ):
+        data, wcs, plot_axes, coord_params = self._prep_animate_args(wcs, plot_axes, axes_units, data_unit)
+
+        return CustomArrayAnimatorWCS(data, wcs, plot_axes, coord_params=coord_params, **kwargs)
+
+
+class SequencePlotter(MatplotlibSequencePlotter):
     def plot(self, *args, **kwargs):
         return super().plot(*args, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ docs = [
   'sphinx-copybutton',
   'sphinx-design',
   'sphinx-gallery',
-  'sphinx-hoverxref',
   'sunpy-sphinx-theme',
 ]
 dev = ["irispy-lmsal[tests,docs]"]


### PR DESCRIPTION
## Summary by Sourcery

Add support and documentation for IRIS v34 raster handling by extending reader flexibility, correcting WCS flipping logic, removing obsolete hoverxref support, updating pre-commit tooling, and introducing a new example for v34 datasets

New Features:
- Add example script for handling and visualizing v34 raster datasets with optional flip reversal

Bug Fixes:
- Fix WCS CDELT3 sign and include PC1_3 header for proper v34 spectrograph data flipping

Enhancements:
- Allow read_files to accept and forward additional keyword arguments to reader functions

CI:
- Upgrade docformatter to v1.7.7 and ruff to v0.11.11 in pre-commit config

Documentation:
- Remove hoverxref extension and related configuration and dependency