### PR TITLE
Added method to output sunpy maps for the SJI

### DIFF
--- a/changelog/64.feature.rst
+++ b/changelog/64.feature.rst
@@ -1,0 +1,1 @@
+Added ``to_maps`` to ``SJICubes`` to allow a user to output a sunpy Map or MapSequence based on how many slices they need.

--- a/examples/south_sji.py
+++ b/examples/south_sji.py
@@ -40,4 +40,17 @@ print(sji_2832)
 ax = sji_2832.plot().get_animation()
 plt.title(f"IRIS SJI {sji_2832.meta['TWAVE1']}", pad=25)
 
+###############################################################################
+# Finally we will output a frame of the SJI into a sunpy Map.
+
+sji_map = sji_2832.to_maps(0)
+print(sji_map)
+
+###############################################################################
+# We can now plot the SJI Map using sunpy Map's plotting capabilities.
+
+fig = plt.figure()
+ax = fig.add_subplot(projection=sji_map.wcs)
+sji_map.plot(axes=ax)
+
 plt.show()

--- a/examples/using_aia_cubes.py
+++ b/examples/using_aia_cubes.py
@@ -51,6 +51,11 @@ aia_collection = read_files(sdo_aia_file, memmap=False)
 print(aia_collection)
 
 ###############################################################################
+# We will then select the 304.
+
+print(aia_collection["304_THIN"])
+
+###############################################################################
 # We will now plot the AIA data in the same manner as the SJI data.
 #
 # You can also change the axis labels and ticks if you so desire.

--- a/examples/using_aia_cubes.py
+++ b/examples/using_aia_cubes.py
@@ -51,7 +51,7 @@ aia_collection = read_files(sdo_aia_file, memmap=False)
 print(aia_collection)
 
 ###############################################################################
-# We will then select the 304.
+# We will then select the 304 bandpass cube.
 
 print(aia_collection["304_THIN"])
 
@@ -61,8 +61,9 @@ print(aia_collection["304_THIN"])
 # You can also change the axis labels and ticks if you so desire.
 # `WCSAxes provides us an API we can use. <https://docs.astropy.org/en/stable/visualization/wcsaxes/index.html>`__
 
-# Note that the .get_animation() is used to animate this example and is not required normally.
 fig = plt.figure()
+# Note that the .get_animation() is used to animate this example
+# and is not required normally.
 aia_collection["304_THIN"].plot(fig=fig).get_animation()
 
 plt.show()

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -156,31 +156,27 @@ class SJICube(SpectrogramCube):
         """
         return self._basic_wcs
 
+    def get_maps(self, index: int | slice | list | None = None):
+        """
+        Returns a set of sunpy maps (as a MapSequence) for each step of the
+        SJI.
+
+        Parameters
+        ----------
+        index : int, slice, list, optional
+            The index of the SJI steps you want.
+            By default None which will return the entire cube as a map sequence.
+        """
+        if index is None:
+            pass
+
 
 class AIACube(SJICube):
-    # TODO: Work out better way to handle this
+    """
+    Subclass of the SJICube.
+
+    It is the same outside of the name.
+    """
+
     def __str__(self) -> str:
-        if self.wcs.world_n_dim == 2:
-            instance_start = self.global_coords["Time (UTC)"]
-            instance_end = None
-        else:
-            instance_start = self.wcs.pixel_to_world(0, 0, 0)[-1]
-            instance_end = self.wcs.pixel_to_world(0, 0, self.data.shape[0] - 1)[-1]
-        return textwrap.dedent(
-            f"""
-            AIACube
-            -------
-            Observatory:           {self.meta.get("TELESCOP", "SDO")}
-            Instrument:            {self.meta.get("INSTRUME")}
-            Bandpass:              {self.meta.get("TWAVE1")}
-            Obs. Start:            {self.meta.get("STARTOBS")}
-            Obs. End:              {self.meta.get("ENDOBS")}
-            Instance Start:        {instance_start}
-            Instance End:          {instance_end}
-            Total Frames in Obs.:  {self.meta.get("NBFRAMES")}
-            IRIS Obs. id:          {self.meta.get("OBSID")}
-            Axis Types:            {self.array_axis_physical_types}
-            Roll:                  {self.meta.get("SAT_ROT")}
-            Cube dimensions:       {self.shape}
-            """,
-        )
+        return super().__str__().replace("SJICube", "AIACube")

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -176,8 +176,8 @@ class SJICube(SpectrogramCube):
             idx_list = range(self.data.shape[-1])
         else:
             idx_list = index
-        data_wcs = [(self.data[..., i], self.basic_wcs[i]) for i in idx_list]
-        times_iso = [self.wcs.pixel_to_world(0, 0, i)[-1].utc.isot for i in idx_list]
+        data_wcs = ((self.data[..., i], self.basic_wcs[i]) for i in idx_list)
+        times_iso = (self.wcs.pixel_to_world(0, 0, i)[-1].utc.isot for i in idx_list)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SunpyMetadataWarning)
             maps = Map(data_wcs, sequence=True)

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -173,16 +173,21 @@ class SJICube(SpectrogramCube):
         if isinstance(index, int):
             idx_list = [index]
         elif index is None:
-            idx_list = range(self.data.shape[-1])
+            idx_list = range(self.data.shape[0])
         else:
             idx_list = index
-        data_wcs = ((self.data[..., i], self.basic_wcs[i]) for i in idx_list)
+        data_wcs = ((self.data[i], self.basic_wcs[i]) for i in idx_list)
         times_iso = (self.wcs.pixel_to_world(0, 0, i)[-1].utc.isot for i in idx_list)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SunpyMetadataWarning)
             maps = Map(data_wcs, sequence=True)
-        for m, t in zip(maps, times_iso, strict=False):
+        for m, t in zip(maps, times_iso, strict=True):
             m.meta["DATE-OBS"] = t
+            m.meta["INSTRUME"] = self.meta.get("INSTRUME", "SJI")
+            m.meta["TELESCOP"] = self.meta.get("TELESCOP", "IRIS")
+            m.meta["EXPTIME"] = self.meta.get("EXPTIME", 0.0)
+            m.meta["TWAVE1"] = self.meta.get("TWAVE1")
+            m.plot_settings["cmap"] = f"irissji{int(self.meta['TWAVE1'])}"
         return maps[0] if isinstance(index, int) else maps
 
 

--- a/irispy/tests/test_sji.py
+++ b/irispy/tests/test_sji.py
@@ -46,25 +46,25 @@ def test_to_map(sjicube_1330):
     # Basic smoke tests
     output = sjicube_1330.to_maps(0)
     assert isinstance(output, sunpy.map.GenericMap)
-    assert output.data.shape == (52, 40)
+    assert output.data.shape == (40, 37)
     assert output.reference_date is not None
 
     output = sjicube_1330.to_maps([0, 2])
     assert isinstance(output, sunpy.map.mapsequence.MapSequence)
-    assert output.data.shape == (52, 40, 2)
+    assert output.data.shape == (40, 37, 2)
     assert np.all([output.reference_date is not None for output in output])
 
     output = sjicube_1330.to_maps(range(1, 3))
     assert isinstance(output, sunpy.map.mapsequence.MapSequence)
-    assert output.data.shape == (52, 40, 2)
+    assert output.data.shape == (40, 37, 2)
     assert np.all([output.reference_date is not None for output in output])
 
     output = sjicube_1330.to_maps(range(0, 12, 4))
     assert isinstance(output, sunpy.map.mapsequence.MapSequence)
-    assert output.data.shape == (52, 40, 3)
+    assert output.data.shape == (40, 37, 3)
     assert np.all([output.reference_date is not None for output in output])
 
     output = sjicube_1330.to_maps()
     assert isinstance(output, sunpy.map.mapsequence.MapSequence)
-    assert output.data.shape == (52, 40, 37)
+    assert output.data.shape == (40, 37, 52)
     assert np.all([output.reference_date is not None for output in output])

--- a/irispy/tests/test_sji.py
+++ b/irispy/tests/test_sji.py
@@ -54,14 +54,14 @@ def test_to_map(sjicube_1330):
     assert output.data.shape == (52, 40, 2)
     assert np.all([output.reference_date is not None for output in output])
 
-    sjicube_1330.to_maps(range(0, 2, 1))
+    output = sjicube_1330.to_maps(range(1, 3))
     assert isinstance(output, sunpy.map.mapsequence.MapSequence)
     assert output.data.shape == (52, 40, 2)
     assert np.all([output.reference_date is not None for output in output])
 
-    sjicube_1330.to_maps(range(0, 4, 2))
+    output = sjicube_1330.to_maps(range(0, 12, 4))
     assert isinstance(output, sunpy.map.mapsequence.MapSequence)
-    assert output.data.shape == (52, 40, 2)
+    assert output.data.shape == (52, 40, 3)
     assert np.all([output.reference_date is not None for output in output])
 
     output = sjicube_1330.to_maps()

--- a/irispy/tests/test_sji.py
+++ b/irispy/tests/test_sji.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+import sunpy.map
+
 AXIS = [
     (
         "custom:pos.helioprojective.lon",
@@ -38,3 +40,31 @@ def test_world_axis_physical_types_sjicube_1400(sjicube_1400):
 def test_world_axis_physical_types_sjicube_1330(sjicube_1330):
     assert np.all(sjicube_1330.shape == (52, 40, 37))
     assert sjicube_1330.array_axis_physical_types == AXIS
+
+
+def test_to_map(sjicube_1330):
+    # Basic smoke tests
+    output = sjicube_1330.to_maps(0)
+    assert isinstance(output, sunpy.map.GenericMap)
+    assert output.data.shape == (52, 40)
+    assert output.reference_date is not None
+
+    output = sjicube_1330.to_maps([0, 2])
+    assert isinstance(output, sunpy.map.mapsequence.MapSequence)
+    assert output.data.shape == (52, 40, 2)
+    assert np.all([output.reference_date is not None for output in output])
+
+    sjicube_1330.to_maps(range(0, 2, 1))
+    assert isinstance(output, sunpy.map.mapsequence.MapSequence)
+    assert output.data.shape == (52, 40, 2)
+    assert np.all([output.reference_date is not None for output in output])
+
+    sjicube_1330.to_maps(range(0, 4, 2))
+    assert isinstance(output, sunpy.map.mapsequence.MapSequence)
+    assert output.data.shape == (52, 40, 2)
+    assert np.all([output.reference_date is not None for output in output])
+
+    output = sjicube_1330.to_maps()
+    assert isinstance(output, sunpy.map.mapsequence.MapSequence)
+    assert output.data.shape == (52, 40, 37)
+    assert np.all([output.reference_date is not None for output in output])


### PR DESCRIPTION
## Summary by Sourcery

Enable converting SJI cubes to Sunpy Map/MapSequence, streamline AIACube string output, and add tests and example usage for the new functionality.

New Features:
- Add SJICube.to_maps method to export SJI data as Sunpy Map or MapSequence with timestamp metadata

Enhancements:
- Simplify AIACube __str__ by delegating to base class and renaming output

Documentation:
- Update example to demonstrate selecting a specific AIA wavelength from the collection

Tests:
- Add tests to verify to_maps outputs for single indices, lists, ranges, and full sequence