### PR TITLE
Improve spectral fitting

### DIFF
--- a/examples/using_aia_cubes.py
+++ b/examples/using_aia_cubes.py
@@ -64,6 +64,6 @@ print(aia_collection["304_THIN"])
 fig = plt.figure()
 # Note that the .get_animation() is used to animate this example
 # and is not required normally.
-aia_collection["304_THIN"].plot(fig=fig).get_animation()
+anim = aia_collection["304_THIN"].plot(fig=fig).get_animation()
 
 plt.show()

--- a/examples/working_with_rasters.py
+++ b/examples/working_with_rasters.py
@@ -77,7 +77,7 @@ fig = plt.figure()
 # This will also "transpose" the data but this is only for visualization purposes
 # We have to set the vmin and vmax, as by default "plot" works out the
 # vmin,vmax from the first slice which in this case is 0.
-mg_ii.plot(fig=fig, plot_axes=["x", "y", None], vmin=0, vmax=1000).get_animation()
+anim = mg_ii.plot(fig=fig, plot_axes=["x", "y", None], vmin=0, vmax=1000).get_animation()
 # The call to `get_animation()` is necessary to display the animation in this example.
 # It is not needed in a normal script.
 


### PR DESCRIPTION
## Summary by Sourcery

Improve the spectral_fitting example by explicitly specifying plot axes and correcting image orientation for the imshow plots

Bug Fixes:
- Transpose net_flux, Doppler shift, and line width arrays for imshow to fix axis orientation

Enhancements:
- Add plot_axes parameter to the si_iv_spec_crop.plot call to explicitly map axes